### PR TITLE
Update supported "babel-eslint" versions in peerDependencies

### DIFF
--- a/packages/eslint-config-webservices-base/package.json
+++ b/packages/eslint-config-webservices-base/package.json
@@ -28,11 +28,11 @@
   },
   "homepage": "https://github.com/MacPaw/eslint-config-webservices#readme",
   "peerDependencies": {
-    "babel-eslint": "^8.0.0",
+    "babel-eslint": "^7.2.3 || ^8.0.0 || ^9.0.0 || ^10.0.0",
     "eslint": "^4.19.1 || ^5.3.0",
     "eslint-plugin-filenames": "^1.2.0",
     "eslint-plugin-import": "^2.15.0",
-    "eslint-plugin-promise": "^3.5.0",
+    "eslint-plugin-promise": "^3.5.0"
   },
   "dependencies": {
     "eslint-config-airbnb-base": "^17.0.0"

--- a/packages/eslint-config-webservices/package.json
+++ b/packages/eslint-config-webservices/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/MacPaw/eslint-config-webservices#readme",
   "peerDependencies": {
-    "babel-eslint": "^7.2.3",
+    "babel-eslint": "^7.2.3 || ^8.0.0 || ^9.0.0 || ^10.0.0",
     "eslint": "^4.19.1 || ^5.3.0",
     "eslint-plugin-filenames": "^1.2.0",
     "eslint-plugin-import": "^2.16.0",


### PR DESCRIPTION
Fixes npm/yarn warnings in projects where "babel-eslint" v8-10 installed

![image](https://user-images.githubusercontent.com/6490265/61810469-feaa5e80-ae47-11e9-833b-ef870b8b92d8.png)
