### PR TITLE
Fix invalid "eslint-config-airbnb-base" version

### DIFF
--- a/packages/eslint-config-webservices-base/package.json
+++ b/packages/eslint-config-webservices-base/package.json
@@ -35,6 +35,6 @@
     "eslint-plugin-promise": "^3.5.0"
   },
   "dependencies": {
-    "eslint-config-airbnb-base": "^17.0.0"
+    "eslint-config-airbnb-base": "^13.1.0"
   }
 }


### PR DESCRIPTION
One more small fix. That dependency was set to non-existent version a long ago.