### PR TITLE
Add react/sort-prop-types rule

### DIFF
--- a/packages/eslint-config-webservices/rules/react.js
+++ b/packages/eslint-config-webservices/rules/react.js
@@ -31,5 +31,9 @@ module.exports = {
     'react/forbid-foreign-prop-types': 'error',
     'react/no-direct-mutation-state': 'error',
     'react/no-access-state-in-setstate': 'error',
+    'react/sort-prop-types': ['error', {
+      callbacksLast: true,
+      noSortAlphabetically: true,
+    }],
   }
 };


### PR DESCRIPTION
Props beginning with "on" should be listen after all other props.
Rule level is `error`.